### PR TITLE
Update mailmerge.py

### DIFF
--- a/mailmerge.py
+++ b/mailmerge.py
@@ -34,7 +34,7 @@ class MailMerge(object):
 
         to_delete = []
 
-        r = re.compile(r' MERGEFIELD "?([^ ]+?)"? (| \\\* MERGEFORMAT )', re.I)
+        r = re.compile(r' MERGEFIELD  "?([^ ]+?)"? (| \\\* MERGEFORMAT )', re.I)
         for part in self.parts.values():
             # Remove attribute that soft-links to other namespaces; other namespaces
             # are not used, so would cause word to throw an error.


### PR DESCRIPTION
Added additional space on re.compile, as word 2010 was failing to merge fields.

document.get_merge_fields() would return field named with an additional preceding space e.g.;
"merge_field_example" would display as " merge_field_example"

As a result the actual merge failed.
This was witnessed on windows XP & 7 Word 2010
