### PR TITLE
Merge rows should not fail if there is a table which is not available

### DIFF
--- a/mailmerge.py
+++ b/mailmerge.py
@@ -149,11 +149,12 @@ class MailMerge(object):
 
     def merge_rows(self, anchor, rows):
         table, idx, template = self.__find_row_anchor(anchor)
-        del table[idx]
-        for i, row_data in enumerate(rows):
-            row = deepcopy(template)
-            self.merge([row], **row_data)
-            table.insert(idx + i, row)
+        if table is not None:
+            del table[idx]
+            for i, row_data in enumerate(rows):
+                row = deepcopy(template)
+                self.merge([row], **row_data)
+                table.insert(idx + i, row)
 
     def __find_row_anchor(self, field, parts=None):
         if not parts:
@@ -163,3 +164,4 @@ class MailMerge(object):
                 for idx, row in enumerate(table):
                     if row.find('.//MergeField[@name="%s"]' % field) is not None:
                         return table, idx, row
+        return None, None, None

--- a/tests/test_merge_table_rows.py
+++ b/tests/test_merge_table_rows.py
@@ -34,6 +34,31 @@ class MergeTableRowsTest(EtreeMixin, unittest.TestCase):
         self.assert_equal_tree(self.expected_tree,
                                list(self.document.parts.values())[0].getroot())
 
+    def test_merge_rows_no_table(self):
+        """
+        Merging of rows should not fail if there is no table with the given
+        column in the document
+        """
+        self.document.merge(
+            student_name='Bouke Haarsma',
+            study='Industrial Engineering and Management',
+            thesis_grade='A',
+            class_code=[
+                {'class_code': 'ECON101', 'class_name': 'Economics 101', 'class_grade': 'A'},
+                {'class_code': 'ECONADV', 'class_name': 'Economics Advanced', 'class_grade': 'B'},
+                {'class_code': 'OPRES', 'class_name': 'Operations Research', 'class_grade': 'A'},
+            ],
+            no_table=[
+                {'no_table': 'Table not available'}
+            ]
+        )
+
+        with tempfile.TemporaryFile() as outfile:
+            self.document.write(outfile)
+
+        self.assert_equal_tree(self.expected_tree,
+                               list(self.document.parts.values())[0].getroot())
+
     def test_merge_unified(self):
         self.document.merge(
             student_name='Bouke Haarsma',


### PR DESCRIPTION
I have the use case where I prepare a replacement dictionary and use the same dict to merge different kind of templates. The user defines what fields he wants to merge in the template.

Currently when there is a table defined in the replacement dictionary which is not available in the template, the code fails.

This pull requests fixes this issue.