### PR TITLE
Added ability to run MailMerge as a context manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,8 @@ Open the file.
 ::
 
     from mailmerge import MailMerge
-    document = MailMerge('input.docx')
+    with MailMerge('input.docx') as document:
+        ...
 
 
 List all merge fields.

--- a/tests/test_issue8.py
+++ b/tests/test_issue8.py
@@ -5,5 +5,5 @@ from mailmerge import MailMerge
 
 class Issue8Test(unittest.TestCase):
     def test(self):
-        document = MailMerge(path.join(path.dirname(__file__), 'test_issue8.docx'))
-        self.assertEqual(document.get_merge_fields(), {'testfield'})
+        with MailMerge(path.join(path.dirname(__file__), 'test_issue8.docx')) as document:
+            self.assertEqual(document.get_merge_fields(), {'testfield'})

--- a/tests/test_macword2011.py
+++ b/tests/test_macword2011.py
@@ -9,18 +9,18 @@ from tests.utils import EtreeMixin
 
 class MacWord2011Test(EtreeMixin, unittest.TestCase):
     def test(self):
-        document = MailMerge(path.join(path.dirname(__file__), 'test_macword2011.docx'))
-        self.assertEqual(document.get_merge_fields(),
-                         set(['first_name', 'last_name', 'country', 'state',
-                              'postal_code', 'date', 'address_line', 'city']))
+        with MailMerge(path.join(path.dirname(__file__), 'test_macword2011.docx')) as document:
+            self.assertEqual(document.get_merge_fields(),
+                             set(['first_name', 'last_name', 'country', 'state',
+                                  'postal_code', 'date', 'address_line', 'city']))
 
-        document.merge(first_name='Bouke', last_name='Haarsma',
-                       country='The Netherlands', state=None,
-                       postal_code='9723 ZA', city='Groningen',
-                       address_line='Helperpark 278d', date='May 22nd, 2013')
+            document.merge(first_name='Bouke', last_name='Haarsma',
+                           country='The Netherlands', state=None,
+                           postal_code='9723 ZA', city='Groningen',
+                           address_line='Helperpark 278d', date='May 22nd, 2013')
 
-        with tempfile.TemporaryFile() as outfile:
-            document.write(outfile)
+            with tempfile.TemporaryFile() as outfile:
+                document.write(outfile)
 
         expected_tree = etree.fromstring(
             '<w:document xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" '

--- a/tests/test_merge_pages.py
+++ b/tests/test_merge_pages.py
@@ -9,17 +9,17 @@ from tests.utils import EtreeMixin, get_document_body_part
 
 class MergeListTest(EtreeMixin, unittest.TestCase):
     def test_pages(self):
-        document = MailMerge(path.join(path.dirname(__file__), 'test_merge_pages.docx'))
-        self.assertEqual(document.get_merge_fields(), {'fieldname'})
+        with MailMerge(path.join(path.dirname(__file__), 'test_merge_pages.docx')) as document:
+            self.assertEqual(document.get_merge_fields(), {'fieldname'})
 
-        document.merge_pages([
-            {'fieldname': "xyz"},
-            {'fieldname': "abc"},
-            {'fieldname': "2b v ~2b"},
-        ])
+            document.merge_pages([
+                {'fieldname': "xyz"},
+                {'fieldname': "abc"},
+                {'fieldname': "2b v ~2b"},
+            ])
 
-        with tempfile.TemporaryFile() as outfile:
-            document.write(outfile)
+            with tempfile.TemporaryFile() as outfile:
+                document.write(outfile)
 
         expected_tree = etree.fromstring('<w:document xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:ns1="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" mc:Ignorable="w14 wp14"><w:body><w:p w:rsidP="007B2B98" w:rsidR="00EC3BBB" w:rsidRDefault="00651722" w:rsidRPr="00651722"><w:r><w:t xml:space="preserve">This is a template for the </w:t></w:r><w:r><w:t>xyz</w:t></w:r><w:r><w:t xml:space="preserve"> merge_list test case</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack" /><w:bookmarkEnd w:id="0" /></w:p><w:sectPr w:rsidR="00EC3BBB" w:rsidRPr="00651722"><w:headerReference ns1:id="rId7" w:type="default" /><w:footerReference ns1:id="rId8" w:type="default" /><w:pgSz w:h="15840" w:w="12240" /><w:pgMar w:bottom="1440" w:footer="708" w:gutter="0" w:header="708" w:left="1440" w:right="1440" w:top="1440" /><w:cols w:space="708" /><w:docGrid w:linePitch="360" /></w:sectPr></w:body><w:br w:type="page" /><w:body><w:p w:rsidP="007B2B98" w:rsidR="00EC3BBB" w:rsidRDefault="00651722" w:rsidRPr="00651722"><w:r><w:t xml:space="preserve">This is a template for the </w:t></w:r><w:r><w:t>abc</w:t></w:r><w:r><w:t xml:space="preserve"> merge_list test case</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack" /><w:bookmarkEnd w:id="0" /></w:p><w:sectPr w:rsidR="00EC3BBB" w:rsidRPr="00651722"><w:headerReference ns1:id="rId7" w:type="default" /><w:footerReference ns1:id="rId8" w:type="default" /><w:pgSz w:h="15840" w:w="12240" /><w:pgMar w:bottom="1440" w:footer="708" w:gutter="0" w:header="708" w:left="1440" w:right="1440" w:top="1440" /><w:cols w:space="708" /><w:docGrid w:linePitch="360" /></w:sectPr></w:body><w:br w:type="page" /><w:body><w:p w:rsidP="007B2B98" w:rsidR="00EC3BBB" w:rsidRDefault="00651722" w:rsidRPr="00651722"><w:r><w:t xml:space="preserve">This is a template for the </w:t></w:r><w:r><w:t>2b v ~2b</w:t></w:r><w:r><w:t xml:space="preserve"> merge_list test case</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack" /><w:bookmarkEnd w:id="0" /></w:p><w:sectPr w:rsidR="00EC3BBB" w:rsidRPr="00651722"><w:headerReference ns1:id="rId7" w:type="default" /><w:footerReference ns1:id="rId8" w:type="default" /><w:pgSz w:h="15840" w:w="12240" /><w:pgMar w:bottom="1440" w:footer="708" w:gutter="0" w:header="708" w:left="1440" w:right="1440" w:top="1440" /><w:cols w:space="708" /><w:docGrid w:linePitch="360" /></w:sectPr></w:body></w:document>')  # noqa
 
@@ -31,17 +31,17 @@ class MergeListTest(EtreeMixin, unittest.TestCase):
         however this template already contains two pages. So the result should
         be 3 * 2 pages.
         """
-        document = MailMerge(path.join(path.dirname(__file__), 'test_merge_pages_paged.docx'))
-        self.assertEqual(document.get_merge_fields(), {'fieldname'})
+        with MailMerge(path.join(path.dirname(__file__), 'test_merge_pages_paged.docx')) as document:
+            self.assertEqual(document.get_merge_fields(), {'fieldname'})
 
-        document.merge_pages([
-            {'fieldname': "xyz"},
-            {'fieldname': "abc"},
-            {'fieldname': "2b v ~2b"},
-        ])
+            document.merge_pages([
+                {'fieldname': "xyz"},
+                {'fieldname': "abc"},
+                {'fieldname': "2b v ~2b"},
+            ])
 
-        with tempfile.TemporaryFile() as outfile:
-            document.write(outfile)
+            with tempfile.TemporaryFile() as outfile:
+                document.write(outfile)
 
         expected_tree = etree.fromstring('<w:document xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:ns1="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" mc:Ignorable="w14 wp14"><w:body><w:p w:rsidP="007B2B98" w:rsidR="00507D2F" w:rsidRDefault="00651722"><w:r><w:t xml:space="preserve">This is a template for the </w:t></w:r><w:r><w:t>xyz</w:t></w:r><w:r><w:t xml:space="preserve"> merge_list test case</w:t></w:r><w:r w:rsidR="00507D2F"><w:t>, page 1</w:t></w:r></w:p><w:p w:rsidR="00507D2F" w:rsidRDefault="00507D2F"><w:r><w:br w:type="page" /></w:r></w:p><w:p w:rsidP="007B2B98" w:rsidR="00EC3BBB" w:rsidRDefault="00507D2F" w:rsidRPr="00651722"><w:r><w:lastRenderedPageBreak /><w:t xml:space="preserve">This is a template for the </w:t></w:r><w:r><w:t>xyz</w:t></w:r><w:r><w:t xml:space="preserve"> merge_list test case</w:t></w:r><w:r><w:t>, page 2</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack" /><w:bookmarkEnd w:id="0" /></w:p><w:sectPr w:rsidR="00EC3BBB" w:rsidRPr="00651722"><w:headerReference ns1:id="rId7" w:type="default" /><w:footerReference ns1:id="rId8" w:type="default" /><w:pgSz w:h="15840" w:w="12240" /><w:pgMar w:bottom="1440" w:footer="708" w:gutter="0" w:header="708" w:left="1440" w:right="1440" w:top="1440" /><w:cols w:space="708" /><w:docGrid w:linePitch="360" /></w:sectPr></w:body><w:br w:type="page" /><w:body><w:p w:rsidP="007B2B98" w:rsidR="00507D2F" w:rsidRDefault="00651722"><w:r><w:t xml:space="preserve">This is a template for the </w:t></w:r><w:r><w:t>abc</w:t></w:r><w:r><w:t xml:space="preserve"> merge_list test case</w:t></w:r><w:r w:rsidR="00507D2F"><w:t>, page 1</w:t></w:r></w:p><w:p w:rsidR="00507D2F" w:rsidRDefault="00507D2F"><w:r><w:br w:type="page" /></w:r></w:p><w:p w:rsidP="007B2B98" w:rsidR="00EC3BBB" w:rsidRDefault="00507D2F" w:rsidRPr="00651722"><w:r><w:lastRenderedPageBreak /><w:t xml:space="preserve">This is a template for the </w:t></w:r><w:r><w:t>abc</w:t></w:r><w:r><w:t xml:space="preserve"> merge_list test case</w:t></w:r><w:r><w:t>, page 2</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack" /><w:bookmarkEnd w:id="0" /></w:p><w:sectPr w:rsidR="00EC3BBB" w:rsidRPr="00651722"><w:headerReference ns1:id="rId7" w:type="default" /><w:footerReference ns1:id="rId8" w:type="default" /><w:pgSz w:h="15840" w:w="12240" /><w:pgMar w:bottom="1440" w:footer="708" w:gutter="0" w:header="708" w:left="1440" w:right="1440" w:top="1440" /><w:cols w:space="708" /><w:docGrid w:linePitch="360" /></w:sectPr></w:body><w:br w:type="page" /><w:body><w:p w:rsidP="007B2B98" w:rsidR="00507D2F" w:rsidRDefault="00651722"><w:r><w:t xml:space="preserve">This is a template for the </w:t></w:r><w:r><w:t>2b v ~2b</w:t></w:r><w:r><w:t xml:space="preserve"> merge_list test case</w:t></w:r><w:r w:rsidR="00507D2F"><w:t>, page 1</w:t></w:r></w:p><w:p w:rsidR="00507D2F" w:rsidRDefault="00507D2F"><w:r><w:br w:type="page" /></w:r></w:p><w:p w:rsidP="007B2B98" w:rsidR="00EC3BBB" w:rsidRDefault="00507D2F" w:rsidRPr="00651722"><w:r><w:lastRenderedPageBreak /><w:t xml:space="preserve">This is a template for the </w:t></w:r><w:r><w:t>2b v ~2b</w:t></w:r><w:r><w:t xml:space="preserve"> merge_list test case</w:t></w:r><w:r><w:t>, page 2</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack" /><w:bookmarkEnd w:id="0" /></w:p><w:sectPr w:rsidR="00EC3BBB" w:rsidRPr="00651722"><w:headerReference ns1:id="rId7" w:type="default" /><w:footerReference ns1:id="rId8" w:type="default" /><w:pgSz w:h="15840" w:w="12240" /><w:pgMar w:bottom="1440" w:footer="708" w:gutter="0" w:header="708" w:left="1440" w:right="1440" w:top="1440" /><w:cols w:space="708" /><w:docGrid w:linePitch="360" /></w:sectPr></w:body></w:document>')  # noqa
 

--- a/tests/test_merge_table_multipart.py
+++ b/tests/test_merge_table_multipart.py
@@ -57,3 +57,5 @@ class MergeTableRowsMultipartTest(EtreeMixin, unittest.TestCase):
             if (part.getroot().tag == '{http://schemas.openxmlformats.org/wordprocessingml/2006/main}document'):
                 self.assert_equal_tree(self.expected_tree, part.getroot())
 
+    def tearDown(self):
+        self.document.close()

--- a/tests/test_merge_table_rows.py
+++ b/tests/test_merge_table_rows.py
@@ -94,3 +94,6 @@ class MergeTableRowsTest(EtreeMixin, unittest.TestCase):
 
         self.assert_equal_tree(self.expected_tree,
                                list(self.document.parts.values())[0].getroot())
+
+    def tearDown(self):
+        self.document.close()

--- a/tests/test_winword2010.py
+++ b/tests/test_winword2010.py
@@ -9,19 +9,19 @@ from tests.utils import EtreeMixin
 
 class Windword2010Test(EtreeMixin, unittest.TestCase):
     def test(self):
-        document = MailMerge(path.join(path.dirname(__file__), 'test_winword2010.docx'))
-        self.assertEqual(document.get_merge_fields(),
-                         set(['Titel', 'Voornaam', 'Achternaam',
-                              'Adresregel_1', 'Postcode', 'Plaats',
-                              'Provincie', 'Land_of_regio']))
+        with MailMerge(path.join(path.dirname(__file__), 'test_winword2010.docx')) as document:
+            self.assertEqual(document.get_merge_fields(),
+                             set(['Titel', 'Voornaam', 'Achternaam',
+                                  'Adresregel_1', 'Postcode', 'Plaats',
+                                  'Provincie', 'Land_of_regio']))
 
-        document.merge(Voornaam='Bouke', Achternaam='Haarsma',
-                       Land_of_regio='The Netherlands', Provincie=None,
-                       Postcode='9723 ZA', Plaats='Groningen',
-                       Adresregel_1='Helperpark 278d\nP.O. Box', Titel='dhr.')
+            document.merge(Voornaam='Bouke', Achternaam='Haarsma',
+                           Land_of_regio='The Netherlands', Provincie=None,
+                           Postcode='9723 ZA', Plaats='Groningen',
+                           Adresregel_1='Helperpark 278d\nP.O. Box', Titel='dhr.')
 
-        with tempfile.NamedTemporaryFile() as outfile:
-            document.write(outfile)
+            with tempfile.NamedTemporaryFile() as outfile:
+                document.write(outfile)
 
         expected_tree = etree.fromstring(
             '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="w14 wp14">'  # noqa


### PR DESCRIPTION
This fixes the resource leak problem as caller can open mailmerge with the with statement which then makes sure that zip file is closed.

This is actually a fairly critical change when using MailMerge on a server (as we do) when lots of zip/docx files are being opened but it is not guaranteed that they are closed.
