### PR TITLE
Optionally return mail-merge fields in list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Open the file.
         ...
 
 
-List all merge fields.
+List all merge fields, by default as Set; optionally pass return_list=True
 ::
 
     print document.get_merge_fields()

--- a/mailmerge.py
+++ b/mailmerge.py
@@ -127,14 +127,20 @@ class MailMerge(object):
                 else:
                     output.writestr(zi.filename, self.zip.read(zi))
 
-    def get_merge_fields(self, parts=None):
+    def get_merge_fields(self, return_list=False, parts=None):
+        '''default return set(<file merge_fields>) scrambles file merge field
+        order; optional return_list maintains that order - helpful for e.g.
+        sequential pyparsing content from other documents'''
         if not parts:
             parts = self.parts.values()
-        fields = set()
+        fields = list()
         for part in parts:
             for mf in part.findall('.//MergeField'):
-                fields.add(mf.attrib['name'])
-        return fields
+                fields.append(mf.attrib['name'])
+        if return_list:
+            return fields
+        else:
+            return set(fields)
 
     def merge_pages(self, replacements):
         """


### PR DESCRIPTION
The default return of mail-merge fields as a set scrambles the order
of the fields; optional param return_list=True preserves that order;
this is useful when using the feilds sequentially to extract content
from other docs