### PR TITLE
Update merge_pages and new merge_sections method

### DIFF
--- a/mailmerge.py
+++ b/mailmerge.py
@@ -3,7 +3,6 @@ import re
 from lxml.etree import Element
 from lxml import etree
 from zipfile import ZipFile, ZIP_DEFLATED
-import xml.etree.ElementTree as ET
 
 NAMESPACES = {
     'w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
@@ -182,8 +181,8 @@ class MailMerge(object):
                                     parts.append(mainSection)
                                 else:
                                     #Page break
-                                    pb   = ET.SubElement(child, '{%(w)s}p'  % NAMESPACES)
-                                    r = ET.SubElement(pb, '{%(w)s}r'  % NAMESPACES)
+                                    pb   = etree.SubElement(child, '{%(w)s}p'  % NAMESPACES)
+                                    r = etree.SubElement(pb, '{%(w)s}r'  % NAMESPACES)
                                     pagebreak = Element('{%(w)s}br' % NAMESPACES)
                                     pagebreak.attrib['{%(w)s}type' % NAMESPACES] = 'page'
                                     r.append(pagebreak)
@@ -261,8 +260,8 @@ class MailMerge(object):
 
                                 else:
                                     intSection = deepcopy(mainSection)
-                                    p   = ET.SubElement(child, '{%(w)s}p'  % NAMESPACES)
-                                    pPr = ET.SubElement(p, '{%(w)s}pPr'  % NAMESPACES)
+                                    pb   = etree.SubElement(child, '{%(w)s}p'  % NAMESPACES)
+                                    r = etree.SubElement(pb, '{%(w)s}r'  % NAMESPACES)
                                     pPr.append(intSection)
                                     parts.append(p)
                     self.merge(parts, **repl) 


### PR DESCRIPTION
This pull request is about creation of a new method named merge_sections and the modification of the merge_pages method.

## Description

merge_pages : it does the same thing than the current one, but not in the same way. The current way does not work with any template and is, in my opinion, not in well accordance with OpenXml format.

merge_sections : 
This method does the same thing than merge_pages, but separates the templates by a section break instead of a page break.

## Motivation and Context

merge_pages : the current method generates 2 body parts and 2 main sections parts in the document. The OpenXml reference guide does not expressly permit that. Other contributors have note in some cases errors messages that indicates an invalid document.

merge_sections : in my opinion, using sections breaks is more appropriate for the purpose of merge_pages. With this method, the user wants to obtain multiple documents in one file (for example, 2 letters in one file). Page break does not suit with that purpose. Page break purpose is simply to go to the next page without having to add useless return caracters in the document.
On the contrary, sections breaks permits this more effectively : with section break, it is possible to deal with multiple headers or footers. 

For example, a letter template with a header only on the first page would be well rendered : 
first merge : page 1 with header, page 2 without header
second merge : page 1 with header, page 2 without header
...
It is not possible with page breaks.

Furthermore, sections breaks have interesting attributes : 
- 'continuous' - Begins the section on the next paragraph.
- 'evenPage' - The section begins on the next even-numbered page, leaving the next odd page blank if necessary.
- 'nextColumn' - The section begins on the following column on the page.
- 'nextPage' - The section begins on the following page.
- 'oddPage' - The section begins on the next odd-numbered page, leaving the next even page blank if necessary.
With merge_sections, it is possible to have theses options and make more complex templates.

## How Has This Been Tested?

The changes have not been much tested so far.
Multiples situations have been tested by comparison of the xml code of the generated document and a document with equivalent manual change.

The testing environnement is Word 2016 for Macintosh.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.