### PR TITLE
Add a new paragraph instead of "&#60;br&#62;" if the text to be merged contains "\n"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /.tox/
 *.pyc
-.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.tox/
 *.pyc
+.vscode/settings.json

--- a/mailmerge.py
+++ b/mailmerge.py
@@ -271,29 +271,51 @@ class MailMerge(object):
             mf.tag = '{%(w)s}r' % NAMESPACES
             mf.extend(children)
 
-            nodes = []
             # preserve new lines in replacement text
             text = text or ''  # text might be None
             text_parts = str(text).replace('\r', '').split('\n')
-            for i, text_part in enumerate(text_parts):
-                text_node = Element('{%(w)s}t' % NAMESPACES)
-                text_node.text = text_part
-                nodes.append(text_node)
 
-                # if not last node add new line node
-                if i < (len(text_parts) - 1):
-                    nodes.append(Element('{%(w)s}br' % NAMESPACES))
+            # step1 insert the first line
+            text_node = etree.Element('{%(w)s}t' % NAMESPACES)
+            text_node.text = text_parts[0]
 
             ph = mf.find('MergeText')
             if ph is not None:
                 # add text nodes at the exact position where
                 # MergeText was found
                 index = mf.index(ph)
-                for node in reversed(nodes):
-                    mf.insert(index, node)
+                mf.insert(index, text_node)
                 mf.remove(ph)
             else:
-                mf.extend(nodes)
+                mf.extend(text_node)
+            
+            current_paragraph = mf.getparent()
+            
+            # step2 insert each remaining line as different paragraph
+            # with the style of the same merge field
+            if(len(text_parts)>1):
+                # get the style of current merge field 
+                # contain paragraph and text
+                # <w:pPr>**</w:pRr>
+                current_paragraph_style = current_paragraph[0]
+                # <w:rPr>**</w:rRr>
+                current_text_style = mf[0]   
+                current_body = current_paragraph.getparent()
+                # find the next insert place
+                insert_index = current_body.index(current_paragraph)+1
+                for k in range(1,len(text_parts)):
+                    paragraph_node = etree.Element('{%(w)s}p' % NAMESPACES)
+                    # copy paragraph style
+                    paragraph_node.append(deepcopy(current_paragraph_style))
+                    # copy text style
+                    text_node = etree.SubElement(paragraph_node,'{%(w)s}r' % NAMESPACES)
+                    text_node.append(deepcopy(current_text_style))
+                    # insert text
+                    etree.SubElement(text_node,'{%(w)s}t' % NAMESPACES).text = text_parts[k]
+                    # insert new paragraph
+                    current_body.insert(insert_index,paragraph_node)
+                    # find the next insert place
+                    insert_index = insert_index + 1
 
     def merge_rows(self, anchor, rows):
         table, idx, template = self.__find_row_anchor(anchor)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just modified the function "__merge_field" for adding  real paragraphs instead of "&#60;br&#62;" if the text to be merged contains "\n".

## Motivation and Context

For example, for field named "text" in docx, there are text to be merged: "1.one\n2.two\n3.three"

![1](https://user-images.githubusercontent.com/8074767/68081725-94915480-fe4d-11e9-8e0d-916328477af3.PNG)

By the old function, it will insert "&#60;br&#62;" to get line break ( In MSword, it shows "Shift+Enter"):

![2](https://user-images.githubusercontent.com/8074767/68081750-e5a14880-fe4d-11e9-8e6a-6afef6427eb4.PNG)

But considering text indentation, (for me, Chinese language), actually we need  "Real Enter".

![3](https://user-images.githubusercontent.com/8074767/68081778-43ce2b80-fe4e-11e9-9a48-850b03ddce21.PNG)

By the old function, it will be:

![4](https://user-images.githubusercontent.com/8074767/68081786-606a6380-fe4e-11e9-8a45-138b49fb54be.PNG)

In other word, now we need two more paragraphs instead of two "&#60;br&#62;".

So I writed some codes to add paragraphs to solve these "bugs",perhaps features?

I hope it will show:

![5](https://user-images.githubusercontent.com/8074767/68081816-bd661980-fe4e-11e9-8784-b52be5f2b365.PNG)

## How Has This Been Tested?

Tested on window10, python 3.6.6.

I run the unittest by `python -m unittest` and the result is `FAILED (failures=8)`

All these failures seem are  the result of test cases, these cases are based on "&#60;br&#62;",It's no surprise that failed. Maybe these test cases need to be changed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
