### PR TITLE
feat: cast text to str that may not be string

### DIFF
--- a/mailmerge.py
+++ b/mailmerge.py
@@ -274,7 +274,7 @@ class MailMerge(object):
 
             nodes = []
             # preserve new lines in replacement text
-            text = text or ''  # text might be None
+            text = str(text) or ''  # text might be None or not str
             text_parts = str(text).replace('\r', '').split('\n')
             for i, text_part in enumerate(text_parts):
                 text_node = Element('{%(w)s}t' % NAMESPACES)


### PR DESCRIPTION
## Description
Case `text` to `str` that may not be string.

## Motivation and Context
In cases that values are int or date maybe this calls `__str__` of it so after that it won't get into exceptions.

## How Has This Been Tested?
Set value to int

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
