### PR TITLE
Add support to docm files #94

### DIFF
--- a/mailmerge.py
+++ b/mailmerge.py
@@ -14,6 +14,7 @@ NAMESPACES = {
 
 CONTENT_TYPES_PARTS = (
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+    'application/vnd.ms-word.document.macroEnabled.main+xml',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml',
 )


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## Expected Behavior
<!--- If you're describing a bug, tell us what should happen -->
<!--- If you're suggesting a change/improvement, tell us how it should work -->
It seems that a very small change to the main python file can allow the script to deal with macro enabled word file format.

## Current Behavior
<!--- If describing a bug, tell us what happens instead of the expected behavior -->
<!--- If suggesting a change/improvement, explain the difference from current behavior -->
Today the .docm file are not usable.

## Possible Solution
<!--- Not obligatory, but suggest a fix/reason for the bug, -->
<!--- or ideas how to implement the addition or change -->

It consists of 
...
CONTENT_TYPES_PARTS = (
    'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
    **_'application/vnd.ms-word.document.macroEnabled.main+xml',_**
    'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml',
    'application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml',
)
...

Initial tests suggest that change is sufficient to get most of the tests to process .docm files.

## Steps to Reproduce (for bugs)
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug. Include code to reproduce, if relevant -->

## Context
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- Providing context helps us come up with a solution that is most useful in the real world -->
<!--- Please upload the Word document you're using -->
I saved the projects docx files as .docm and tested the impact of the modification.

## Your Environment
<!--- Include as many relevant details about the environment you experienced the bug in -->
* Python version:
* docx-mailmerge version:
latest git version