### PR TITLE
Lxml etree serialzation io_encoder error workaround

### DIFF
--- a/mailmerge.py
+++ b/mailmerge.py
@@ -123,7 +123,7 @@ class MailMerge(object):
         zi = self.zip.getinfo(fn)
         return zi, etree.parse(self.zip.open(zi))
 
-    def write(self, file):
+    def write(self, file, encoding=None):
         # Replace all remaining merge fields with empty values
         for field in self.get_merge_fields():
             self.merge(**{field: ''})
@@ -131,10 +131,10 @@ class MailMerge(object):
         with ZipFile(file, 'w', ZIP_DEFLATED) as output:
             for zi in self.zip.filelist:
                 if zi in self.parts:
-                    xml = etree.tostring(self.parts[zi].getroot())
+                    xml = etree.tostring(self.parts[zi].getroot(), encoding=encoding)
                     output.writestr(zi.filename, xml)
                 elif zi == self._settings_info:
-                    xml = etree.tostring(self.settings.getroot())
+                    xml = etree.tostring(self.settings.getroot(), encoding=encoding)
                     output.writestr(zi.filename, xml)
                 else:
                     output.writestr(zi.filename, self.zip.read(zi))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add encoding parameter to MailMerge.write

## Motivation and Context
`MailMerge.write(file)` occasionally causes `lxml.etree.SerialisationError: IO_ENCODER` exception.
xml = etree.tostring(self.parts[zi].getroot(), encoding='UTF-8') eliminates the problem.<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
